### PR TITLE
Build executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,31 +37,29 @@ Now you should see this
 Take a look into [ui/js](https://github.com/Equanox/gotron/tree/master/ui/js), [ui/react](https://github.com/Equanox/gotron/tree/master/ui/react),
 [ui/typescript-react](https://github.com/Equanox/gotron/tree/master/ui/typescript) or [ui/vue](https://github.com/Equanox/gotron/tree/master/ui/vue) for details.
 
-For plain Javascript use
+For plain javascript (default) use
 
     npm run build  
 
-For the react frontend use
+For other frontend use
 
-    npm run build:react
+    npm run build:${frontend}
 
-For the typescript-react frontend use
+where ${frontend} is one out of (js|react|typescript|vue).
 
-    npm run build:typescript
-
-For the vueJS frontend use
-
-    npm run build:vue    
-
-then type
+Then type
 
     go build
 
-to create an executable gotron or gorton.exe (windows).
+to create an executable gotron or gotron.exe (windows).
 
 Type
 
     ./gotron
+    
+or
+
+    gotron.exe
 
 to bring up go backend and electron frontend.
 
@@ -93,14 +91,14 @@ to run the application.
 
 Cross Platform Compilation is supported for following cases.
 
-- Linux:
+- Linux to:
     - Linux
     - Windows (Wine version 1.8 or later is required)
     - Mac (Compiles but not tested)
-- Windows:
+- Windows to:
     - Windows
     - Linux
-- Mac: (No tests for compilation on mac have been performed)
+- Mac to: (No tests for compilation on mac have been performed)
 
 # License
 MIT  

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ A boilerplate for cross-platform desktop applications using Golang and Electron.
 ## Run
 **go**, **nodejs** and **npm (v2.0 or later)** should be available on your system.  
 
-Install Electron globally
-
-    npm install -g electron
-
 Clone to your go workspace (e.g. go/src)
 
     git clone https://github.com/equanox/gotron
@@ -77,17 +73,17 @@ Build the required frontend first.
 
 For windows distribution type
 
-    npm run dist:win
+    npm run pack:win
 
 For linux distribution type
 
-    npm run dist:linux
+    npm run pack:linux
 
 For mac distribution type
 
-    npm run dist:mac
+    npm run pack:mac
 
-Distributables will be created in ./dist/\<OS\>-unpacked/
+Distributables will be created in ./dist/(linux|mac|win)/
 
 Execute 
 

--- a/README.md
+++ b/README.md
@@ -71,19 +71,13 @@ Reload updated index.js using 'r' key.
 
 Build the required frontend first.
 
-For windows distribution type
+For required distribution type
 
-    npm run pack:win
+    npm run pack:${os}
 
-For linux distribution type
+where ${os} is one out of (linux|mac|win).
 
-    npm run pack:linux
-
-For mac distribution type
-
-    npm run pack:mac
-
-Distributables will be created in ./dist/(linux|mac|win)/
+Distributables will be created in ./dist/${os}/
 
 Execute 
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,16 @@ Reload updated index.js using 'r' key.
 
 Build the required frontend first.
 
+The electron application will be built with **electron-builder**.
+For more information about build configuration visit [electron.build](https://www.electron.build/)
+
 For required distribution type
 
     npm run pack:${os}
 
 where ${os} is one out of (linux|mac|win).
 
-Distributables will be created in ./dist/${os}/
+Apllication will be created in ./dist/${os}/
 
 Execute 
 

--- a/README.md
+++ b/README.md
@@ -78,17 +78,9 @@ For required distribution type
 
 where ${os} is one out of (linux|mac|win).
 
-Apllication will be created in ./dist/${os}/
+Apllication will be created in ./dist/${os}/ with an executable named **gotron** inside this directory.
 
-Execute 
-
-    ./gotron
-
-or (windows)
-
-    gotron.exe
-
-to run the application.
+Run this executable to start the application.
 
 ### Cross Platfrom Compilation
 

--- a/package.json
+++ b/package.json
@@ -28,13 +28,16 @@
     "postbuild:typescript": "cpy ui/typescript/build/*.* app/assets/ && move-cli app/assets/bundle.js app/assets/js/index.js && echo Build Ui {ui/typescript}, cp bundle.js to app/assets/js/index.js",
     "build:vue": "cd ui/vue && npm run build",
     "postbuild:vue": "cpy ui/vue/build/*.* app/assets/ && move-cli app/assets/bundle.js app/assets/js/index.js && echo Build Ui {ui/vue}, cp bundle.js to app/assets/js/index.js",
-    "dist": "dist:win && dist:linux && dist:mac",
-    "dist:win": "build -w && cross-env-shell GOOS=windows GOARCH=amd64 go build -tags prod -ldflags -H=windowsgui",
-    "postdist:win": "move-cli gotron.exe dist/win-unpacked/gotron.exe",
-    "dist:linux": "build -l && cross-env-shell GOOS=linux GOARCH=amd64 go build -tags prod",
-    "postdist:linux": "move-cli gotron dist/linux-unpacked/gotron",
-    "dist:mac": "build -m && cross-env-shell GOOS=darwin GOARCH=amd64 go build -tags prod",
-    "postdist:mac": "move-cli gotron dist/mac/gotron"
+    "pack": "pack:win && pack:linux && pack:mac",
+    "prepack:win": "del-cli -f dist/win",
+    "pack:win": "build -w && cross-env-shell GOOS=windows GOARCH=amd64 go build -tags prod -ldflags -H=windowsgui",
+    "postpack:win": "move-cli --mkdirp dist/win-unpacked/ dist/win/electron/ && move-cli gotron.exe dist/win/gotron.exe",
+    "prepack:linux": "del-cli -f dist/linux",
+    "pack:linux": "build -l && cross-env-shell GOOS=linux GOARCH=amd64 go build -tags prod",
+    "postpack:linux": "move-cli --mkdirp dist/linux-unpacked/ dist/linux/ && move-cli gotron dist/linux/gotron",
+    "prepack:mac": "del-cli -f dist/mac",
+    "pack:mac": "build -m && cross-env-shell GOOS=darwin GOARCH=amd64 go build -tags prod",
+    "postpack:mac": "move-cli gotron dist/mac/gotron"
   },
   "build": {
     "appId": "equanox.gotron",

--- a/ui_prod.go
+++ b/ui_prod.go
@@ -18,5 +18,5 @@ func FrontendPath() (string, string, string) {
 	}
 	exPath := filepath.Dir(ex)
 
-	return exPath + "/", "electron-rampup", ""
+	return exPath + "/electron/", "electron-rampup", ""
 }


### PR DESCRIPTION
- Renamed Scripts from dist to pack.
- Distribution/Packaging: Moved all electron components to subdir "electron".
- Renamed build dirs to linux, win or mac. No "-unpacked" anymore.
- Updated README.md for these changes.